### PR TITLE
Added sync mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The first argument can be:
 The second argument is the minimum length of the internal buffer that is
 required before flushing.
 
-The third argument is a flag that make SonicBoom work synchronously or
+The third argument is a flag that, when true, causes `SonicBoom` to perform synchronous writes.
 
 It will emit the `'ready'` event when a file descriptor is available.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ The second argument is the minimum length of the internal buffer that is
 required before flushing.
 
 The third argument is a flag that make SonicBoom work synchronously or
-not.
 
 It will emit the `'ready'` event when a file descriptor is available.
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ Extremely fast utf8-only stream implementation to write to files and
 file descriptors.
 
 This implementation is partial, but support backpressure and `.pipe()` in is here.
-However, it is 20x faster than Node Core `fs.createWriteStream()`:
+However, it is 2-3x faster than Node Core `fs.createWriteStream()`:
 
 ```
-benchSonic*1000: 476.229ms
-benchCore*1000: 8250.532ms
-benchSonic*1000: 478.423ms
-benchCore*1000: 8096.463ms
+benchSonic*1000: 3405.774ms
+benchSonicSync*1000: 3664.278ms
+benchSonic4k*1000: 3375.185ms
+benchSonicSync4k*1000: 3631.575ms
+benchCore*1000: 10922.763ms
 ```
 
 Note that if this is used to log to a windows terminal (`cmd.exe` or

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ for (var i = 0; i < 10; i++) {
 
 ## API
 
-### SonicBoom(String|Number, (minLength))
+### SonicBoom(String|Number, [minLength], [sync])
 
 Creates a new instance of SonicBoom.
 
@@ -51,6 +51,9 @@ The first argument can be:
 
 The second argument is the minimum length of the internal buffer that is
 required before flushing.
+
+The third argument is a flag that make SonicBoom work synchronously or
+not.
 
 It will emit the `'ready'` event when a file descriptor is available.
 

--- a/bench.js
+++ b/bench.js
@@ -8,26 +8,52 @@ var core = fs.createWriteStream('/dev/null')
 var fd = fs.openSync('/dev/null', 'w')
 var sonic = new SonicBoom(fd)
 var sonic4k = new SonicBoom(fd, 4096)
+var sonicSync = new SonicBoom(fd, 0, true)
+var sonicSync4k = new SonicBoom(fd, 4096, true)
+
+var MAX = 10000
+
+function str () {
+  var res = ''
+
+  for (var i = 0; i < 10; i++) {
+    res += 'hello'
+  }
+
+  return res
+}
 
 setTimeout(doBench, 100)
 
 var run = bench([
   function benchSonic (cb) {
     sonic.once('drain', cb)
-    for (var i = 0; i < 10000; i++) {
-      sonic.write('hello world')
+    for (var i = 0; i < MAX; i++) {
+      sonic.write(str())
+    }
+  },
+  function benchSonicSync (cb) {
+    sonicSync.once('drain', cb)
+    for (var i = 0; i < MAX; i++) {
+      sonicSync.write(str())
     }
   },
   function benchSonic4k (cb) {
     sonic4k.once('drain', cb)
-    for (var i = 0; i < 10000; i++) {
-      sonic4k.write('hello world')
+    for (var i = 0; i < MAX; i++) {
+      sonic4k.write(str())
+    }
+  },
+  function benchSonicSync4k (cb) {
+    sonicSync4k.once('drain', cb)
+    for (var i = 0; i < MAX; i++) {
+      sonicSync4k.write(str())
     }
   },
   function benchCore (cb) {
     core.once('drain', cb)
-    for (var i = 0; i < 10000; i++) {
-      core.write('hello world')
+    for (var i = 0; i < MAX; i++) {
+      core.write(str())
     }
   }
 ], 1000)


### PR DESCRIPTION
This is mainly to solve https://github.com/pinojs/pino/issues/542, however I found out that it gives us a  20% speed bump when logging things with sync mode in pino benchmarks.

Benchmarks in pino with sonic-boom master:

```
$ node benchmarks/basic.bench.js
benchPino*10000: 162.391ms
benchPinoExtreme*10000: 108.874ms
benchPinoNodeStream*10000: 245.955ms
```

Benchmarks in pino with this PR, enabling sync mode for both destination and extreme:

```
$ node benchmarks/basic.bench.js
benchPino*10000: 147.822ms
benchPinoExtreme*10000: 83.608ms
benchPinoNodeStream*10000: 243.117ms
```

cc @jsumners @davidmarkclements