### PR TITLE
Fix finish not being emitted after end() while reopening

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const flatstr = require('flatstr')
 const inherits = require('util').inherits
 
 function openFile (file, sonic) {
+  sonic._opening = true
   sonic._writing = true
   sonic.file = file
   fs.open(file, 'a', (err, fd) => {
@@ -15,6 +16,7 @@ function openFile (file, sonic) {
     }
 
     sonic.fd = fd
+    sonic._opening = false
     sonic._writing = false
 
     sonic.emit('ready')
@@ -195,6 +197,12 @@ SonicBoom.prototype.end = function () {
   if (!this._writing && this._buf.length > 0 && this.fd >= 0) {
     actualWrite(this)
     return
+  }
+
+  if (this._writing && this._opening) {
+    this.once('ready', () => {
+      actualWrite(this)
+    })
   }
 
   if (this._writing) {

--- a/test.js
+++ b/test.js
@@ -348,6 +348,28 @@ function buildTests (test, sync) {
     })
   })
 
+  test('end after reopen', (t) => {
+    t.plan(4)
+
+    const dest = file()
+    const stream = new SonicBoom(dest, 4096, sync)
+
+    stream.once('ready', () => {
+      t.pass('ready emitted')
+      const after = dest + '-moved'
+      stream.reopen(after)
+      stream.write('after reopen\n')
+      stream.on('finish', () => {
+        t.pass('finish emitted')
+        fs.readFile(after, 'utf8', (err, data) => {
+          t.error(err)
+          t.equal(data, 'after reopen\n')
+        })
+      })
+      stream.end()
+    })
+  })
+
   test('reopen with file', (t) => {
     t.plan(9)
 


### PR DESCRIPTION
I noticed that the `finish` event (and the `close` event) isn't being emitted if `end()` is called after `reopen()` and the opening of the new file isn't finished.

This fixes the problem and adds a test case for it.