### PR TITLE
Fix finish not being emitted

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,6 +161,13 @@ SonicBoom.prototype.reopen = function (file) {
     throw new Error('SonicBoom destroyed')
   }
 
+  if (this._opening) {
+    this.once('ready', () => {
+      this.reopen(file)
+    })
+    return
+  }
+
   if (this._ending) {
     return
   }
@@ -188,6 +195,13 @@ SonicBoom.prototype.end = function () {
     throw new Error('SonicBoom destroyed')
   }
 
+  if (this._opening) {
+    this.once('ready', () => {
+      this.end()
+    })
+    return
+  }
+
   if (this._ending) {
     return
   }
@@ -197,12 +211,6 @@ SonicBoom.prototype.end = function () {
   if (!this._writing && this._buf.length > 0 && this.fd >= 0) {
     actualWrite(this)
     return
-  }
-
-  if (this._writing && this._opening) {
-    this.once('ready', () => {
-      actualWrite(this)
-    })
   }
 
   if (this._writing) {

--- a/test.js
+++ b/test.js
@@ -370,6 +370,47 @@ function buildTests (test, sync) {
     })
   })
 
+  test('end after 2x reopen', (t) => {
+    t.plan(4)
+
+    const dest = file()
+    const stream = new SonicBoom(dest, 4096, sync)
+
+    stream.once('ready', () => {
+      t.pass('ready emitted')
+      stream.reopen(dest + '-moved')
+      const after = dest + '-moved-moved'
+      stream.reopen(after)
+      stream.write('after reopen\n')
+      stream.on('finish', () => {
+        t.pass('finish emitted')
+        fs.readFile(after, 'utf8', (err, data) => {
+          t.error(err)
+          t.equal(data, 'after reopen\n')
+        })
+      })
+      stream.end()
+    })
+  })
+
+  test('end if not ready', (t) => {
+    t.plan(3)
+
+    const dest = file()
+    const stream = new SonicBoom(dest, 4096, sync)
+    const after = dest + '-moved'
+    stream.reopen(after)
+    stream.write('after reopen\n')
+    stream.on('finish', () => {
+      t.pass('finish emitted')
+      fs.readFile(after, 'utf8', (err, data) => {
+        t.error(err)
+        t.equal(data, 'after reopen\n')
+      })
+    })
+    stream.end()
+  })
+
   test('reopen with file', (t) => {
     t.plan(9)
 


### PR DESCRIPTION
I found another case, similar to the one from #24, where the `finish` event wasn't emitted.

