### PR TITLE
fs.openSync for option sync:true

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ The options are:
   required to be full before flushing.
 * `sync`: perform writes synchronously (similar to `console.log`).
 
-A `SonicBoom` instance will emit the `'ready'` event when a file descriptor is available.
+For `sync:false`  a `SonicBoom` instance will emit the `'ready'` event when a file descriptor is available. 
+For `sync:true` the file descriptor will be available when the instance is created, before the `ready` event is fired. 
 
 ### SonicBoom#write(string)
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ The options are:
 * `sync`: perform writes synchronously (similar to `console.log`).
 
 For `sync:false`  a `SonicBoom` instance will emit the `'ready'` event when a file descriptor is available. 
-For `sync:true` the file descriptor will be available when the instance is created, before the `ready` event is fired. 
+For `sync:true` this is not relevant because the `'ready'` event will be fired when the `SonicBoom` instance is created, before it can be subscribed to. 
+   
 
 ### SonicBoom#write(string)
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ function openFile (file, sonic) {
   sonic._opening = true
   sonic._writing = true
   sonic.file = file
-  fs.open(file, 'a', (err, fd) => {
+
+  function fileOpened (err, fd) {
     if (err) {
       sonic.emit('error', err)
       return
@@ -42,7 +43,14 @@ function openFile (file, sonic) {
     if (len > 0 && len > sonic.minLength && !sonic.destroyed) {
       actualWrite(sonic)
     }
-  })
+  }
+
+  if (sonic.sync) {
+    const fd = fs.openSync(file, 'a')
+    fileOpened(null, fd)
+  } else {
+    fs.open(file, 'a', fileOpened)
+  }
 }
 
 function SonicBoom (opts) {

--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ function openFile (file, sonic) {
   sonic._writing = true
   sonic.file = file
 
+  // NOTE: 'error' and 'ready' events emitted below only relevant when sonic.sync===false
+  // for sync mode, there is no way to add a listener that will receive these
+
   function fileOpened (err, fd) {
     if (err) {
       sonic.emit('error', err)

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ function openFile (file, sonic) {
   if (sonic.sync) {
     const fd = fs.openSync(file, 'a')
     fileOpened(null, fd)
+    process.nextTick(() => sonic.emit('ready'))
   } else {
     fs.open(file, 'a', fileOpened)
   }

--- a/test.js
+++ b/test.js
@@ -50,11 +50,7 @@ function buildTests (test, sync) {
       t.pass('ready emitted')
     }
 
-    if (sync) {
-      onReady()
-    } else {
-      stream.on('ready', onReady)
-    }
+    stream.on('ready', onReady)
 
     t.ok(stream.write('hello world\n'))
     t.ok(stream.write('something else\n'))
@@ -139,11 +135,7 @@ function buildTests (test, sync) {
       t.pass('ready emitted')
     }
 
-    if (sync) {
-      onReady()
-    } else {
-      stream.on('ready', onReady)
-    }
+    stream.on('ready', onReady)
 
     t.ok(stream.write('hello world\n'))
     t.ok(stream.write('something else\n'))
@@ -232,11 +224,7 @@ function buildTests (test, sync) {
       t.pass('ready emitted')
     }
 
-    if (sync) {
-      onReady()
-    } else {
-      stream.on('ready', onReady)
-    }
+    stream.on('ready', onReady)
 
     t.ok(stream.write('hello world\n'))
     t.ok(stream.write('something else\n'))
@@ -278,11 +266,7 @@ function buildTests (test, sync) {
       t.pass('ready emitted')
     }
 
-    if (sync) {
-      onReady()
-    } else {
-      stream.on('ready', onReady)
-    }
+    stream.on('ready', onReady)
 
     t.ok(stream.write('hello world\n'))
     t.ok(stream.write('something else\n'))
@@ -334,10 +318,6 @@ function buildTests (test, sync) {
       }
 
       stream.once('ready', onReady)
-
-      if (sync) {
-        onReady()
-      }
     })
   })
 
@@ -377,18 +357,10 @@ function buildTests (test, sync) {
       fs.renameSync(dest, after)
       stream.reopen()
 
-      if (sync) {
-        innerOnReady()
-      } else {
-        stream.once('ready', innerOnReady)
-      }
+      stream.once('ready', innerOnReady)
     }
 
-    if (sync) {
-      onReady()
-    } else {
-      stream.once('ready', onReady)
-    }
+    stream.once('ready', onReady)
   })
 
   test('reopen if not open', (t) => {
@@ -428,11 +400,7 @@ function buildTests (test, sync) {
       stream.end()
     }
 
-    if (sync) {
-      onReady()
-    } else {
-      stream.once('ready', onReady)
-    }
+    stream.once('ready', onReady)
   })
 
   test('end after 2x reopen', (t) => {
@@ -457,11 +425,7 @@ function buildTests (test, sync) {
       stream.end()
     }
 
-    if (sync) {
-      onReady()
-    } else {
-      stream.once('ready', onReady)
-    }
+    stream.once('ready', onReady)
   })
 
   test('end if not ready', (t) => {
@@ -514,11 +478,7 @@ function buildTests (test, sync) {
         })
       }
 
-      if (sync) {
-        onReady()
-      } else {
-        stream.once('ready', onReady)
-      }
+      stream.once('ready', onReady)
     })
   })
 

--- a/test.js
+++ b/test.js
@@ -760,3 +760,14 @@ test('write enormously large buffers sync with utf8 multi-byte split', (t) => {
     t.pass('close emitted')
   })
 })
+
+// for context see this issue https://github.com/pinojs/pino/issues/871
+test('file specified by dest path available immediately when options.sync is true', (t) => {
+  t.plan(3)
+  const dest = file()
+  const stream = new SonicBoom({ dest, sync: true })
+  t.ok(stream.write('hello world\n'))
+  t.ok(stream.write('something else\n'))
+  stream.flushSync()
+  t.pass('file opened and written to without error')
+})


### PR DESCRIPTION
changes file open to `fs.openSync`, when `option.sync === true`

This has implications for the `ready` event - which is no longer relevant for `sync` option, as the file descriptor is ready and the event is fired as part of the instantiation - before it's possible to attach the event listener. 

Fixes pinojs/pino/issues/871
