### PR TITLE
Migrate from vars to ES6 syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm i sonic-boom
 const SonicBoom = require('sonic-boom')
 const sonic = new SonicBoom({ fd: process.stdout.fd }) // or { dest: '/path/to/destination' }
 
-for (var i = 0; i < 10; i++) {
+for (let i = 0; i < 10; i++) {
   sonic.write('hello sonic\n')
 }
 ```

--- a/bench.js
+++ b/bench.js
@@ -1,24 +1,24 @@
 'use strict'
 
-var bench = require('fastbench')
-var SonicBoom = require('./')
-var Console = require('console').Console
-var fs = require('fs')
+const bench = require('fastbench')
+const SonicBoom = require('./')
+const Console = require('console').Console
+const fs = require('fs')
 
-var core = fs.createWriteStream('/dev/null')
-var fd = fs.openSync('/dev/null', 'w')
-var sonic = new SonicBoom({ fd })
-var sonic4k = new SonicBoom({ fd, minLength: 4096 })
-var sonicSync = new SonicBoom({ fd, sync: true })
-var sonicSync4k = new SonicBoom({ fd, minLength: 4096, sync: true })
-var dummyConsole = new Console(fs.createWriteStream('/dev/null'))
+const core = fs.createWriteStream('/dev/null')
+const fd = fs.openSync('/dev/null', 'w')
+const sonic = new SonicBoom({ fd })
+const sonic4k = new SonicBoom({ fd, minLength: 4096 })
+const sonicSync = new SonicBoom({ fd, sync: true })
+const sonicSync4k = new SonicBoom({ fd, minLength: 4096, sync: true })
+const dummyConsole = new Console(fs.createWriteStream('/dev/null'))
 
-var MAX = 10000
+const MAX = 10000
 
 function str () {
-  var res = ''
+  let res = ''
 
-  for (var i = 0; i < 10; i++) {
+  for (let i = 0; i < 10; i++) {
     res += 'hello'
   }
 
@@ -27,39 +27,39 @@ function str () {
 
 setTimeout(doBench, 100)
 
-var run = bench([
+const run = bench([
   function benchSonic (cb) {
     sonic.once('drain', cb)
-    for (var i = 0; i < MAX; i++) {
+    for (let i = 0; i < MAX; i++) {
       sonic.write(str())
     }
   },
   function benchSonicSync (cb) {
     sonicSync.once('drain', cb)
-    for (var i = 0; i < MAX; i++) {
+    for (let i = 0; i < MAX; i++) {
       sonicSync.write(str())
     }
   },
   function benchSonic4k (cb) {
     sonic4k.once('drain', cb)
-    for (var i = 0; i < MAX; i++) {
+    for (let i = 0; i < MAX; i++) {
       sonic4k.write(str())
     }
   },
   function benchSonicSync4k (cb) {
     sonicSync4k.once('drain', cb)
-    for (var i = 0; i < MAX; i++) {
+    for (let i = 0; i < MAX; i++) {
       sonicSync4k.write(str())
     }
   },
   function benchCore (cb) {
     core.once('drain', cb)
-    for (var i = 0; i < MAX; i++) {
+    for (let i = 0; i < MAX; i++) {
       core.write(str())
     }
   },
   function benchConsole (cb) {
-    for (var i = 0; i < MAX; i++) {
+    for (let i = 0; i < MAX; i++) {
       dummyConsole.log(str())
     }
     setImmediate(cb)

--- a/check.js
+++ b/check.js
@@ -1,11 +1,11 @@
 'use strict'
 
 const SonicBoom = require('.')
-const sonic = new SonicBoom(process.stdout.fd)
+const sonic = new SonicBoom({ fd: process.stdout.fd })
 
 let count = 0
 function scheduleWrites () {
-  for (var i = 0; i < 1000; i++) {
+  for (let i = 0; i < 1000; i++) {
     sonic.write('hello sonic\n')
     console.log('hello console')
   }

--- a/example.js
+++ b/example.js
@@ -3,6 +3,6 @@
 const SonicBoom = require('.')
 const sonic = new SonicBoom({ fd: process.stdout.fd }) // or 'destination'
 
-for (var i = 0; i < 10; i++) {
+for (let i = 0; i < 10; i++) {
   sonic.write('hello sonic\n')
 }

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function openFile (file, sonic) {
     }
 
     // start
-    var len = sonic._buf.length
+    const len = sonic._buf.length
     if (len > 0 && len > sonic.minLength && !sonic.destroyed) {
       actualWrite(sonic)
     }
@@ -63,7 +63,7 @@ function SonicBoom (opts) {
     return new SonicBoom(opts)
   }
 
-  var { fd, dest, minLength, sync } = opts || {}
+  let { fd, dest, minLength, sync } = opts || {}
 
   fd = fd || dest
 
@@ -139,7 +139,7 @@ function SonicBoom (opts) {
       return
     }
 
-    var len = this._buf.length
+    const len = this._buf.length
     if (this._reopening) {
       this._writing = false
       this._reopening = false
@@ -188,11 +188,11 @@ SonicBoom.prototype.write = function (data) {
   }
 
   this._buf += data
-  var len = this._buf.length
+  const len = this._buf.length
   if (!this._writing && len > this.minLength) {
     actualWrite(this)
   }
-  return len < 16384
+  return len < MAX_WRITE
 }
 
 SonicBoom.prototype.flush = function () {
@@ -296,8 +296,8 @@ SonicBoom.prototype.destroy = function () {
 
 function actualWrite (sonic) {
   sonic._writing = true
-  var buf = sonic._buf
-  var release = sonic.release
+  let buf = sonic._buf
+  const release = sonic.release
   if (buf.length > MAX_WRITE) {
     buf = buf.slice(0, MAX_WRITE)
     sonic._buf = sonic._buf.slice(MAX_WRITE)
@@ -308,7 +308,7 @@ function actualWrite (sonic) {
   sonic._writingBuf = buf
   if (sonic.sync) {
     try {
-      var written = fs.writeSync(sonic.fd, buf, 'utf8')
+      const written = fs.writeSync(sonic.fd, buf, 'utf8')
       release(null, written)
     } catch (err) {
       release(err)

--- a/index.js
+++ b/index.js
@@ -192,7 +192,7 @@ SonicBoom.prototype.write = function (data) {
   if (!this._writing && len > this.minLength) {
     actualWrite(this)
   }
-  return len < MAX_WRITE
+  return len < 16384
 }
 
 SonicBoom.prototype.flush = function () {

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ const proxyquire = require('proxyquire')
 const SonicBoom = require('.')
 
 const files = []
-var count = 0
+let count = 0
 
 function file () {
   const file = path.join(os.tmpdir(), `sonic-boom-${process.pid}-${process.hrtime().toString()}-${count++}`)
@@ -223,7 +223,7 @@ function buildTests (test, sync) {
     t.ok(stream.write('hello world\n'))
     t.ok(stream.write('something else\n'))
 
-    var fail = t.fail
+    const fail = t.fail
     stream.on('drain', fail)
 
     // bad use of timer


### PR DESCRIPTION
* Migrates from `var`s to ES6 syntax, sot that there are no more `var`s in the code base
* Also fixes config typo in `check.js`