### PR TITLE
Do not emit 'error' if we are throwing it with no listeners.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,11 @@ function openFile (file, sonic) {
       sonic._opening = false
 
       if (sonic.sync) {
-        process.nextTick(() => sonic.emit('error', err))
+        process.nextTick(() => {
+          if (sonic.listenerCount('error') > 0) {
+            sonic.emit('error', err)
+          }
+        })
       } else {
         sonic.emit('error', err)
       }

--- a/test.js
+++ b/test.js
@@ -933,3 +933,14 @@ test('file specified by dest path available immediately when options.sync is tru
   stream.flushSync()
   t.pass('file opened and written to without error')
 })
+
+test('sync error handling', (t) => {
+  t.plan(1)
+  try {
+    /* eslint no-new: off */
+    new SonicBoom({ dest: '/path/to/nowwhere', sync: true })
+    t.fail('must throw synchronously')
+  } catch (err) {
+    t.pass('an error happened')
+  }
+})


### PR DESCRIPTION
Fixes https://github.com/pinojs/pino/issues/995.